### PR TITLE
Fix restore_cookie with removing duplicated cookie

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,8 @@ Metrics/BlockLength:
   Enabled: false
 Metrics/LineLength:
   Enabled: false
+Metrics/MethodLength:
+  Enabled: false
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 Layout/SpaceBeforeBlockBraces:

--- a/lib/capybara/sessionkeeper.rb
+++ b/lib/capybara/sessionkeeper.rb
@@ -25,6 +25,7 @@ module Capybara
       cookies = %w[yml yaml].include?(options[:format]) ? YAML.load(data) : Marshal.load(data)
       cookies.each do |d|
         begin
+          driver.browser.manage.delete_cookie d[:name]
           driver.browser.manage.add_cookie d
         rescue StandardError => e
           skip_invalid_cookie_domain_error(e)


### PR DESCRIPTION
It seemed there were duplicated cookies. (which have the same 'name' but different values)
I confirmed the issue since August 2019.

Debug code
_lib/capybara/sessionkeeper.rb_

```ruby
@@ -23,13 +23,17 @@ module Capybara
     def restore_cookies_from_data(data, options = {})
       raise CookieError, "visit must be performed to restore cookies" if ['data:,', 'about:blank'].include?(current_url)
       cookies = %w[yml yaml].include?(options[:format]) ? YAML.load(data) : Marshal.load(data)
+      puts driver.browser.manage.all_cookies
       cookies.each do |d|
         begin
           driver.browser.manage.add_cookie d
         rescue StandardError => e
           skip_invalid_cookie_domain_error(e)
         end
       end
+      puts driver.browser.manage.all_cookies
       driver.browser.manage.all_cookies
     end
```

With `rspec ./spec/capybara/sessionkeeper_spec.rb:109`

Found duplicated cookies

```
{:name=>"_testapp_session", :value=>"B0dQnf5hx3w7WkoSJr6bFmG64678a9EfvC044ghN5pLg0gqVX0uDaDwVH3BsDifoDWB8A7alh2FV1kKTP6tfYHsQzoKdeDTlUKjH8a24GJZfBlzf95f8taKvhfChaPKYhGoZOfjF8ra7v0CeF08%2BV9S06wLdb3WKaN04--lJ1JyIW9ynhftXTn--v76g%2FlsYKFhFaK6MFsR7hw%3D%3D", :path=>"/", :domain=>"testapp-capybara-sessionkeeper.herokuapp.com", :expires=>nil, :secure=>true}
{:name=>"_testapp_session", :value=>"9vGXbvwrrnRNyFUji7i%2FsWUHSCi8pvAjCaGqRK0oJWwAQIv1j0OYZ5AeV2LUC6jYWdzR62Msx5KynqQzEuBUCoIIcTApza9aERZEfMJRdCieBX%2BW6Nnz3cS1IJqjyQTB5LAMB6SgBwPYTSdSC2o%3D--tkE4joXqGm9JRVt3--hbTVHj%2Fkp19WihJbHy2eIA%3D%3D", :path=>"/", :domain=>"testapp-capybara-sessionkeeper.herokuapp.com", :expires=>nil, :secure=>false}
```

I also confirmed that it doesn't lead to error to call 'driver.browser.manage.delete_cookie' twice.
(-> delete_cookie won't be error even when there is no target cookie.)